### PR TITLE
Update colors for Command Palette

### DIFF
--- a/dark/WezTerm/Readme.md
+++ b/dark/WezTerm/Readme.md
@@ -23,6 +23,10 @@ config.colors = {
 	selection_fg = '#9e8a74',
 	selection_bg = '#564538',
 
+	split = '#4C3E32',
+
+	visual_bell = "#db7666",
+
 	ansi = {
 		'#352a21',
 		'#ac493e',
@@ -80,6 +84,9 @@ config.window_frame = {
 	inactive_titlebar_bg = '#352a21',
 }
 
+-- Command Palette
+config.command_palette_bg_color = "#44382D"
+config.command_palette_fg_color = "#c4a389"
 
 return config
 ```

--- a/dark/WezTerm/Squirrelsong Dark.lua
+++ b/dark/WezTerm/Squirrelsong Dark.lua
@@ -11,6 +11,10 @@ config.colors = {
 	selection_fg = '#9e8a74',
 	selection_bg = '#564538',
 
+	split = '#4C3E32',
+
+	visual_bell = "#db7666",
+
 	ansi = {
 		'#352a21',
 		'#ac493e',
@@ -67,3 +71,7 @@ config.window_frame = {
 	active_titlebar_bg = '#574131',
 	inactive_titlebar_bg = '#352a21',
 }
+
+-- Command Palette
+config.command_palette_bg_color = "#44382D"
+config.command_palette_fg_color = "#c4a389"


### PR DESCRIPTION
1. I noticed there was a room to improve colours for Command Palette to match the main theme
 
### Before

![CleanShot 2024-04-29 at 03 33 59@2x](https://github.com/sapegin/squirrelsong/assets/579331/1e90b8cc-ebca-4a94-86e0-b0a754d0b104)

### After

![CleanShot 2024-04-29 at 02 57 40@2x](https://github.com/sapegin/squirrelsong/assets/579331/9c481c53-41f4-4634-91cf-d80fdd95106f)

**Note:** The other options I used to style the Command Palette are:
- `config.command_palette_rows = 7`
- `config.command_palette_font_size = 15`

I'll add them as a separate PR for the `dotfiles` repo in case you like the final look.

2. The split line color had a default tint which was more into either light bluish or greenish which looks odd. Updated to be of a lighter brown-ish variant

### Before

![CleanShot 2024-04-29 at 03 42 55@2x](https://github.com/sapegin/squirrelsong/assets/579331/55b7a180-0ba7-45bf-9d26-95af6d3f4b52)

### After

![CleanShot 2024-04-29 at 03 45 20@2x](https://github.com/sapegin/squirrelsong/assets/579331/af3005ce-dc0c-4fd9-a5f2-9c3523eacb46)

3. I noticed you have two sources of truth for the Wezterm colors, one in here, another - inside the `dotfiles` repo at https://github.com/sapegin/dotfiles/blob/060b0dd6a26b7a793a57f52b37059562ed51b76a/tilde/.wezterm.lua. 

I assumed the dotfiles are more up-to-date so I added [missing](https://github.com/sapegin/dotfiles/blob/060b0dd6a26b7a793a57f52b37059562ed51b76a/tilde/.wezterm.lua#L40) `visual_bell` color back into the Squirrelsong theme here. I believe it's prudent to keep only one copy of theme colors though and reference that single source from inside dotfiles but it's up to you of course how to organise files 😛 But now, changes need to happen in both places to keep things consistent. User go to this repository first of all when it comes to the theme and supported apps.