### PR TITLE
Add revdiff themes

### DIFF
--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -60,6 +60,8 @@ const EXTRA_FILES = [
   // Files without extension
   'themes/Ghostty/Squirrelsong Dark',
   'themes/Ghostty/Squirrelsong Dark Deep Purple',
+  'themes/revdiff/squirrelsong-light',
+  'themes/revdiff/squirrelsong-dark-deep-purple',
 ];
 
 const IGNORES = [

--- a/themes/Obsidian/Squirrelsong/theme.css
+++ b/themes/Obsidian/Squirrelsong/theme.css
@@ -174,7 +174,7 @@ body,
   --color-purple: var(--sqrl-magenta);
   --color-purple-rgb: 172, 155, 197;
   --color-pink: var(--sqrl-brightPink);
-  --color-pink-rgb: 232, 125, 164;
+  --color-pink-rgb: 219, 112, 151;
 
   --background-primary: var(--sqrl-gray180);
   --background-primary-alt: var(--sqrl-gray170);

--- a/themes/revdiff/Readme.md
+++ b/themes/revdiff/Readme.md
@@ -1,0 +1,46 @@
+# Squirrelsong Theme for [revdiff](https://github.com/umputun/revdiff)
+
+Squirrelsong themes for the revdiff terminal diff viewer, in **Light** and **Dark Deep Purple** variants.
+
+## Installation
+
+revdiff loads themes from `~/.config/revdiff/themes/`.
+
+### From a local file
+
+```sh
+# Light
+revdiff --install-theme ./squirrelsong-light
+
+# Dark Deep Purple
+revdiff --install-theme ./squirrelsong-dark-deep-purple
+```
+
+Or copy the theme files there manually:
+
+```sh
+cp squirrelsong-light squirrelsong-dark-deep-purple ~/.config/revdiff/themes/
+```
+
+## Usage
+
+```sh
+# Apply a theme
+revdiff --theme squirrelsong-light
+revdiff --theme squirrelsong-dark-deep-purple
+
+# List available themes
+revdiff --list-themes
+```
+
+Set a default theme in `~/.config/revdiff/config`:
+
+```ini
+theme = squirrelsong-dark-deep-purple
+```
+
+Or via environment variable:
+
+```sh
+export REVDIFF_THEME=squirrelsong-dark-deep-purple
+```

--- a/themes/revdiff/config.json
+++ b/themes/revdiff/config.json
@@ -1,0 +1,34 @@
+{
+  "themes": [
+    {
+      "file": "squirrelsong-dark-deep-purple",
+      "scheme": "darkDp",
+      "context": {
+        "name": "squirrelsong-dark-deep-purple",
+        "description": "warm, muted deep purple theme with transparent chrome and a lavender accent",
+        "accent": "purple070",
+        "insertedBackground": "greenDim",
+        "deletedBackground": "redDim",
+        "insertedWordBackground": "green",
+        "deletedWordBackground": "red",
+        "cursorBackground": "",
+        "treeBackground": "",
+        "statusColors": "color-status-fg = {{accent}}",
+        "chromaStyle": "rose-pine-moon"
+      }
+    },
+    {
+      "file": "squirrelsong-light",
+      "scheme": "light",
+      "context": {
+        "name": "squirrelsong-light",
+        "description": "warm, muted light theme with white panes and a yellow accent",
+        "accent": "yellowContrast",
+        "cursorBackground": "",
+        "treeBackground": "color-tree-bg = {{textBackground}}",
+        "statusColors": "color-status-fg = {{terminalForeground}}\ncolor-status-bg = {{textBackground}}",
+        "chromaStyle": "rose-pine-dawn"
+      }
+    }
+  ]
+}

--- a/themes/revdiff/revdiff.template.ini
+++ b/themes/revdiff/revdiff.template.ini
@@ -1,0 +1,27 @@
+# name: {{name}}
+# description: {{description}}
+# author: Artem Sapegin
+
+chroma-style = {{chromaStyle}}
+color-accent = {{accent}}
+color-border = {{border}}
+color-normal = {{terminalForeground}}
+color-muted = {{secondaryTextForeground}}
+color-selected-fg = {{terminalForeground}}
+color-selected-bg = {{selectionBackground}}
+color-annotation = {{warningForeground}}
+color-cursor-fg = {{accent}}
+{{cursorBackground}}
+color-add-fg = {{successForeground}}
+color-add-bg = {{insertedBackground}}
+color-remove-fg = {{errorForeground}}
+color-remove-bg = {{deletedBackground}}
+color-word-add-bg = {{insertedWordBackground}}
+color-word-remove-bg = {{deletedWordBackground}}
+color-modify-fg = {{warningForeground}}
+color-modify-bg = {{warningBackground}}
+{{treeBackground}}
+color-diff-bg = {{textBackground}}
+{{statusColors}}
+color-search-fg = {{matchForeground}}
+color-search-bg = {{matchBackground}}

--- a/themes/revdiff/squirrelsong-dark-deep-purple
+++ b/themes/revdiff/squirrelsong-dark-deep-purple
@@ -1,0 +1,27 @@
+# name: squirrelsong-dark-deep-purple
+# description: warm, muted deep purple theme with transparent chrome and a lavender accent
+# author: Artem Sapegin
+
+chroma-style = rose-pine-moon
+color-accent = #ae95c7
+color-border = #644e88
+color-normal = #bea3d9
+color-muted = #866db0
+color-selected-fg = #bea3d9
+color-selected-bg = #4c3c6b
+color-annotation = #d8a851
+color-cursor-fg = #ae95c7
+
+color-add-fg = #709855
+color-add-bg = #44603b
+color-remove-fg = #ce574a
+color-remove-bg = #703a2f
+color-word-add-bg = #558240
+color-word-remove-bg = #ac493e
+color-modify-fg = #d8a851
+color-modify-bg = #503d20
+
+color-diff-bg = #271e38
+color-status-fg = #ae95c7
+color-search-fg = #cbb5e3
+color-search-bg = #a65472

--- a/themes/revdiff/squirrelsong-light
+++ b/themes/revdiff/squirrelsong-light
@@ -1,0 +1,28 @@
+# name: squirrelsong-light
+# description: warm, muted light theme with white panes and a yellow accent
+# author: Artem Sapegin
+
+chroma-style = rose-pine-dawn
+color-accent = #bf8a18
+color-border = #c9c4cf
+color-normal = #4c4b4e
+color-muted = #8c8792
+color-selected-fg = #4c4b4e
+color-selected-bg = #f8e7a0
+color-annotation = #c88539
+color-cursor-fg = #bf8a18
+
+color-add-fg = #657d38
+color-add-bg = #f2f4f1
+color-remove-fg = #c06159
+color-remove-bg = #faf4f4
+color-word-add-bg = #dde2d7
+color-word-remove-bg = #f5e5e4
+color-modify-fg = #c88539
+color-modify-bg = #f7e7d5
+color-tree-bg = #fdfdfe
+color-diff-bg = #fdfdfe
+color-status-fg = #4c4b4e
+color-status-bg = #fdfdfe
+color-search-fg = #4c4b4e
+color-search-bg = #e698b5


### PR DESCRIPTION
Adds [revdiff](https://github.com/umputun/revdiff) CLI tool themes.

NOTE: Not sure these are the best color combinations, but it's a good starting point.

This PR also fixed existing lint error.

## Dark Deep Purple

<img width="2522" height="2692" alt="Screenshot 2026-07-02 at 04 46 PM@2x" src="https://github.com/user-attachments/assets/95a3a952-3a57-4bdd-8097-ecccdb2cea0b" />

## Light

<img width="2506" height="2692" alt="Screenshot 2026-07-02 at 04 46 PM@2x" src="https://github.com/user-attachments/assets/5e8fa0c0-b622-4681-91f4-f59b53fc29db" />
